### PR TITLE
Cross-platform csv upload support.

### DIFF
--- a/csv_admin/admin.py
+++ b/csv_admin/admin.py
@@ -102,7 +102,8 @@ class CsvFileAdmin(admin.ModelAdmin):
         if valid_rows is None or invalid_rows is None:
             valid_rows = []
             invalid_rows = []
-            reader = csv.DictReader(instance.csv)
+            f_csv = open(instance.csv.path, 'rU')
+            reader = csv.DictReader(f_csv)
             for row in reader:
                 form_instance = form_class(row)
                 if form_instance.is_valid():
@@ -120,6 +121,7 @@ class CsvFileAdmin(admin.ModelAdmin):
                 # Save forms into cache to speed up load time during validation.
                 cache.set(valid_forms_cache_key, valid_rows)
                 cache.set(invalid_forms_cache_key, invalid_rows)
+            f_csv.close()
 
         invalid_row_count = len(invalid_rows)
         row_count = len(valid_rows) + invalid_row_count


### PR DESCRIPTION
PNWMoths was crashing on a CSV import. It was reporting that we should try turning on "Universal Newline Mode" for the csv file.

How to Produce this error:
Export a CSV of records from the pnwmoths.biol.wwu.edu BSD server
Modify the CSV file in Mac OSX Excel
Save the CSV file
Upload to bsd server and try to validate

A sample file - http://philipbjorge.pwdev.org/media/csv_admin/species_speciesrecord-4.csv

Googling suggested that the problem could have been caused by saving the file on a mac and/or saving the file with excel. Universal newline mode fixes both issues.

http://www.python.org/dev/peps/pep-0278/
